### PR TITLE
Implement limiting the number of todos gotten

### DIFF
--- a/server/src/main/java/umm3601/todo/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todo/TodoDatabase.java
@@ -95,8 +95,16 @@ public class TodoDatabase {
       filteredTodos = filterTodosByStatus(filteredTodos, targetStatus);
     }
 
+    if (queryParams.containsKey("limit")) {
+      String limitParam = queryParams.get("limit").get(0);
+      try {
+        int limit = Integer.parseInt(limitParam);
+        filteredTodos = filterTodosWithLimit(filteredTodos, limit);
+      } catch (NumberFormatException e) {
+        throw new BadRequestResponse("Specified limit '" + limitParam + "' can't be parsed to an integer");
+      }
+    }
     return filteredTodos;
-
   }
 
 
@@ -123,5 +131,9 @@ public class TodoDatabase {
 
   public Todo[] filterTodosByStatus(Todo[] todos, boolean targetStatus) {
     return Arrays.stream(todos).filter(x -> x.status == targetStatus).toArray(Todo[]::new);
+  }
+
+  public Todo[] filterTodosWithLimit(Todo[] todos, int maxNumberOfTodos) {
+    return Arrays.copyOfRange(todos, 0, Math.min(maxNumberOfTodos, todos.length));
   }
 }

--- a/server/src/main/java/umm3601/todo/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todo/TodoDatabase.java
@@ -99,6 +99,8 @@ public class TodoDatabase {
       String limitParam = queryParams.get("limit").get(0);
       try {
         int limit = Integer.parseInt(limitParam);
+        // Treat negative limits as zero.
+        limit = Math.max(limit, 0);
         filteredTodos = filterTodosWithLimit(filteredTodos, limit);
       } catch (NumberFormatException e) {
         throw new BadRequestResponse("Specified limit '" + limitParam + "' can't be parsed to an integer");

--- a/server/src/test/java/umm3601/todo/FilterTodosByArbitraryCombinationsFromDB.java
+++ b/server/src/test/java/umm3601/todo/FilterTodosByArbitraryCombinationsFromDB.java
@@ -24,6 +24,11 @@ public class FilterTodosByArbitraryCombinationsFromDB {
     Todo[] kodosTodos = db.listTodos(queryParams);
 
     queryParams.clear();
+    queryParams.put("limit", Arrays.asList(new String[] { "1" }));
+    queryParams.put("owner", Arrays.asList(new String[] { "Kodos" }));
+    Todo[] limitedKodosTodos = db.listTodos(queryParams);
+
+    queryParams.clear();
     queryParams.put("category", Arrays.asList(new String[] { "production" }));
     Todo[] productionTodos = db.listTodos(queryParams);
 
@@ -39,15 +44,17 @@ public class FilterTodosByArbitraryCombinationsFromDB {
     Todo[] kangSalesCompleteTodos = db.listTodos(queryParams);
 
     queryParams.clear();
+    queryParams.put("limit", Arrays.asList(new String[] { "0" }));
     queryParams.put("owner", Arrays.asList(new String[] { "Kang" }));
     queryParams.put("category", Arrays.asList(new String[] { "sales" }));
-    queryParams.put("status", Arrays.asList(new String[] { "incomplete" }));
-    Todo[] kangSalesIncompleteTodos = db.listTodos(queryParams);
+    queryParams.put("status", Arrays.asList(new String[] { "complete" }));
+    Todo[] limitedKangSalesCompleteTodos = db.listTodos(queryParams);
 
     assertEquals(2, kodosTodos.length, "Incorrect total number of todos with owner Kodos");
+    assertEquals(1, limitedKodosTodos.length, "Incorrect total number of todos with owner Kodos and limit 1");
     assertEquals(1, productionTodos.length, "Incorrect total number of todos with category production");
     assertEquals(1, kodosProductionTodos.length, "Incorrect total number of todos with owner Kodos and category production");
     assertEquals(1, kangSalesCompleteTodos.length, "Incorrect total number of todos with owner Kang and category sales and status complete");
-    assertEquals(0, kangSalesIncompleteTodos.length, "Incorrect total number of todos with owner Kodos and category sales and status incomplete");
+    assertEquals(0, limitedKangSalesCompleteTodos.length, "Incorrect total number of todos with owner Kang and category sales and status complete and limit 0");
   }
 }

--- a/server/src/test/java/umm3601/todo/LimitTodosFromDB.java
+++ b/server/src/test/java/umm3601/todo/LimitTodosFromDB.java
@@ -35,14 +35,14 @@ public class LimitTodosFromDB {
     TodoDatabase db = new TodoDatabase(dbFileName);
     Map<String, List<String>> queryParams = new HashMap<>();
 
-    queryParams.put("category", Arrays.asList(new String[] { limit }));
-    Todo[] categoryTodos = db.listTodos(queryParams);
+    queryParams.put("limit", Arrays.asList(new String[] { Integer.toString(limit) }));
+    Todo[] limitedTodos = db.listTodos(queryParams);
 
-    assertEquals(count, categoryTodos.length, "Incorrect total number of limited todos");
+    assertEquals(count, limitedTodos.length, "Incorrect total number of limited todos");
   }
 
 
-  public static Stream<Arguments> categoriesAndCountsTodosParams() {
+  public static Stream<Arguments> limitsAndCountsTodosParams() {
     return Stream.of(
         Arguments.of("/test-todos-1.json", 2, 2),
         Arguments.of("/test-todos-2.json", 6, 0),

--- a/server/src/test/java/umm3601/todo/LimitTodosFromDB.java
+++ b/server/src/test/java/umm3601/todo/LimitTodosFromDB.java
@@ -1,0 +1,51 @@
+package umm3601.todo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests umm3601.user.TodoDatabase listTodo functionality
+ */
+public class LimitTodosFromDB {
+
+  @ParameterizedTest
+  @MethodSource("limitsAndCountsTodosParams")
+  public void testFilterTodosWithLimit(String dbFileName, int limit, int count) throws IOException {
+    TodoDatabase db = new TodoDatabase(dbFileName);
+    Todo[] allTodos = db.listTodos(new HashMap<>());
+
+    Todo[] limitedTodos = db.filterTodosWithLimit(allTodos, limit);
+
+    assertEquals(count, limitedTodos.length, "Incorrect total number of limited todos");
+  }
+
+  @ParameterizedTest
+  @MethodSource("limitsAndCountsTodosParams")
+  public void testListTodosWithLimit(String dbFileName, int limit, int count) throws IOException {
+    TodoDatabase db = new TodoDatabase(dbFileName);
+    Map<String, List<String>> queryParams = new HashMap<>();
+
+    queryParams.put("category", Arrays.asList(new String[] { limit }));
+    Todo[] categoryTodos = db.listTodos(queryParams);
+
+    assertEquals(count, categoryTodos.length, "Incorrect total number of limited todos");
+  }
+
+
+  public static Stream<Arguments> categoriesAndCountsTodosParams() {
+    return Stream.of(
+        Arguments.of("/test-todos-1.json", 2, 2),
+        Arguments.of("/test-todos-2.json", 6, 0),
+        Arguments.of("/test-todos-3.json", 0, 0));
+  }
+}

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -152,6 +152,40 @@ public class TodoControllerSpec {
     });
   }
 
+  @ParameterizedTest
+  @MethodSource("params")
+  public void GET_to_request_limit_2_todos(
+      TodoDatabase db,
+      TodoController todoController) throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put("status", Arrays.asList(new String[] { "2" }));
+
+    when(ctx.queryParamMap()).thenReturn(queryParams);
+
+    // Call the method on the mock controller
+    todoController.getTodos(ctx);
+
+    // Confirm that `json` was called with all the todos.
+    ArgumentCaptor<Todo[]> argument = ArgumentCaptor.forClass(Todo[].class);
+    verify(ctx).json(argument.capture());
+    assertEquals(Math.min(db.size(), 2), argument.getValue().length);
+  }
+
+  @ParameterizedTest
+  @MethodSource("params")
+  public void GET_with_illegal_limit_throws_error(
+      TodoDatabase db,
+      TodoController todoController) throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put("status", Arrays.asList(new String[] { "I'm not an integer!" }));
+
+    when(ctx.queryParamMap()).thenReturn(queryParams);
+
+    Assertions.assertThrows(BadRequestResponse.class, () -> {
+      todoController.getTodos(ctx);
+    });
+  }
+
 
   public static Stream<Arguments> params() {
     Arguments[] arguments = new Arguments[dbFileNames.length];

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -202,7 +202,20 @@ public class TodoControllerSpec {
     assertEquals(0, argument.getValue().length);
   }
 
+  @ParameterizedTest
+  @MethodSource("params")
+  public void GET_with_hexidecimal_limit_throws_error(
+      TodoDatabase db,
+      TodoController todoController) throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put("limit", Arrays.asList(new String[] { "0xFF" }));
 
+    when(ctx.queryParamMap()).thenReturn(queryParams);
+
+    Assertions.assertThrows(BadRequestResponse.class, () -> {
+      todoController.getTodos(ctx);
+    });
+  }
 
   public static Stream<Arguments> params() {
     Arguments[] arguments = new Arguments[dbFileNames.length];

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -186,6 +186,23 @@ public class TodoControllerSpec {
     });
   }
 
+  @ParameterizedTest
+  @MethodSource("params")
+  public void GET_with_negative_limit_is_treated_as_zero(
+      TodoDatabase db,
+      TodoController todoController) throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put("limit", Arrays.asList(new String[] { "-50" }));
+
+    when(ctx.queryParamMap()).thenReturn(queryParams);
+    todoController.getTodos(ctx);
+
+    ArgumentCaptor<Todo[]> argument = ArgumentCaptor.forClass(Todo[].class);
+    verify(ctx).json(argument.capture());
+    assertEquals(0, argument.getValue().length);
+  }
+
+
 
   public static Stream<Arguments> params() {
     Arguments[] arguments = new Arguments[dbFileNames.length];

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -158,7 +158,7 @@ public class TodoControllerSpec {
       TodoDatabase db,
       TodoController todoController) throws IOException {
     Map<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("status", Arrays.asList(new String[] { "2" }));
+    queryParams.put("limit", Arrays.asList(new String[] { "2" }));
 
     when(ctx.queryParamMap()).thenReturn(queryParams);
 
@@ -177,7 +177,7 @@ public class TodoControllerSpec {
       TodoDatabase db,
       TodoController todoController) throws IOException {
     Map<String, List<String>> queryParams = new HashMap<>();
-    queryParams.put("status", Arrays.asList(new String[] { "I'm not an integer!" }));
+    queryParams.put("limit", Arrays.asList(new String[] { "I'm not an integer!" }));
 
     when(ctx.queryParamMap()).thenReturn(queryParams);
 


### PR DESCRIPTION
Pagination is *not* supported—rather, the server sends the client the first <var>n</var> todos, without provisions for accessing subsequent todos. (Which specific todos are sent might depend on how the server orders todos internally.)

Closes #11 
Closes #2 