### PR TITLE
Close the InputStreamReader in the Database constructor

### DIFF
--- a/server/src/main/java/umm3601/user/Database.java
+++ b/server/src/main/java/umm3601/user/Database.java
@@ -26,6 +26,7 @@ public class Database {
     Gson gson = new Gson();
     InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream(userDataFile));
     allUsers = gson.fromJson(reader, User[].class);
+    reader.close();
   }
 
   public int size() {


### PR DESCRIPTION
Explicitly close the InputStreamReader in the Database constructor.

This change was recommended by the LGTM tool.

See also 86077c1, which was the same fix, but in the TodoDatabase class.